### PR TITLE
[007-API_06]

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
 
     testImplementation("io.mockk:mockk:1.13.3")
+    testImplementation("io.kotest:kotest-assertions-core:5.5.4")
     implementation("com.ninja-squad:springmockk:3.0.1")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/example/payment/service/PaymentStatusService.kt
+++ b/src/main/kotlin/com/example/payment/service/PaymentStatusService.kt
@@ -94,7 +94,7 @@ class PaymentStatusService(
         )
     }
 
-    fun saveAsFailure(orderId: Long, errorCode: ErrorCode) {
+    fun saveAsFailure(orderId: Long, errorCode: ErrorCode): Unit {
         val order = getOrderByOrderId(orderId)
             .apply {
                 orderStatus = OrderStatus.FAILED

--- a/src/test/kotlin/com/example/payment/service/PaymentServiceTest.kt
+++ b/src/test/kotlin/com/example/payment/service/PaymentServiceTest.kt
@@ -1,0 +1,110 @@
+package com.example.payment.service
+
+import com.example.payment.exception.ErrorCode.*
+import com.example.payment.exception.PaymentException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.LocalDateTime
+
+@ExtendWith(MockKExtension::class)
+class PaymentServiceTest {
+
+    @RelaxedMockK // 좀더 유연하 Mocking
+    lateinit var paymentStatusService: PaymentStatusService
+
+    @MockK
+    lateinit var accountService: AccountService
+
+    @InjectMockKs
+    lateinit var paymentService: PaymentService
+
+    @Test
+    @DisplayName("SuccessPaymentTest")
+    fun `결제 성공`() {
+
+        // given
+        val request = PayServiceRequest(
+            paymentUserId = "paymentUserId",
+            amount = 1000L,
+            merchantTransactionId = "merchantTransactionId",
+            orderName = "orderName"
+        )
+
+        every {
+            paymentStatusService.savePayRequest(any(), any(), any(), any())
+
+        } returns 1L
+
+        every {
+            accountService.useAccount(any())
+        } returns "payMethodTransactionId"
+
+        every {
+            paymentStatusService.saveAsSuccess(any(), any())
+        } returns Pair("transactionId", LocalDateTime.MIN)
+
+
+        // when
+        val result = this.paymentService.pay(request)
+
+        // then
+        result.amount shouldBe 1000L
+        result.paymentUserId shouldNotBe "paymentUser"
+        result.transactionId shouldBe "transactionId"
+
+        verify(exactly = 0) {
+            paymentStatusService.saveAsFailure(any(), any())
+        }
+
+        verify(exactly = 1) {
+            paymentStatusService.saveAsSuccess(any(), any())
+        }
+    }
+
+    @Test
+    @DisplayName("FailurePaymentTest")
+    fun `결제 실패`() {
+        // given
+        val request = PayServiceRequest(
+            paymentUserId = "paymentUserId",
+            amount = 1000L,
+            merchantTransactionId = "merchantTransactionId",
+            orderName = "orderName"
+        )
+
+        every {
+            paymentStatusService.savePayRequest(any(), any(), any(), any())
+        } returns 1L
+
+        every {
+            accountService.useAccount(any())
+        } throws PaymentException(LACK_BALANCE)
+
+        // when
+        val result = shouldThrow<PaymentException> {
+            paymentService.pay(request)
+        }
+
+        // then
+        result.errorCode shouldBe LACK_BALANCE
+
+        verify(exactly = 0) {
+            paymentStatusService.saveAsSuccess(any(), any())
+        }
+        verify(exactly = 1) {
+            paymentStatusService.saveAsFailure(any(), any())
+        }
+
+    }
+}


### PR DESCRIPTION
Changes
---
결제 요청 관련 성공 실패 유닛 테스트 구현
MockK 사용
Background
---
kotest-assertions-core 라이브러리 추가

교훈
---
kotlin mock 테스트 방식에 익숙해지자